### PR TITLE
fix(ci): use rustsec/audit-check action for CVSS 4.0 support

### DIFF
--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -19,8 +19,7 @@ jobs:
       - name: Install Rust toolchain
         uses: dtolnay/rust-toolchain@stable
         
-      - name: Install cargo-audit
-        run: cargo install cargo-audit
-        
-      - name: Run audit
-        run: cargo audit
+      - name: Security audit
+        uses: rustsec/audit-check@v2
+        with:
+          token: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
Fixes the Security Audit workflow failing due to CVSS 4.0 format not being supported by cargo-audit CLI.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated security audit workflow to use an automated GitHub Action for enhanced security scanning.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->