### PR TITLE
Revert "chore(deps): bump uuid from 1.21.0 to 1.22.0 in the rust-dependencies group"

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3299,9 +3299,9 @@ checksum = "b6c140620e7ffbb22c2dee59cafe6084a59b5ffc27a8859a5f0d494b5d52b6be"
 
 [[package]]
 name = "uuid"
-version = "1.22.0"
+version = "1.21.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a68d3c8f01c0cfa54a75291d83601161799e4a89a39e0929f4b0354d88757a37"
+checksum = "b672338555252d43fd2240c714dc444b8c6fb0a5c5335e65a07bba7742735ddb"
 dependencies = [
  "getrandom 0.4.1",
  "js-sys",


### PR DESCRIPTION
Reverts AriajSarkar/ByteHub#20